### PR TITLE
Making CC parameter within HMAC confirmation email optional.

### DIFF
--- a/src/Parsers/TatraBankaSimpleMailParser.php
+++ b/src/Parsers/TatraBankaSimpleMailParser.php
@@ -38,7 +38,7 @@ class TatraBankaSimpleMailParser implements ParserInterface
         }
 
         if (!$res) {
-            $comfortpayHmacPattern = '/AMT=(.*) CURR=(.*) VS=(.*) RES=(.*) AC=(.*) TRES=(.*) CID=(.*) CC=(.*) TID=([0-9]*) TIMESTAMP=([0-9]*) HMAC=(.*) ECDSA_KEY=(.) ECDSA=(.*)/m';
+            $comfortpayHmacPattern = '/AMT=(.*) CURR=(.*) VS=(.*) RES=(.*) AC=(.*) TRES=(.*) CID=([0-9]*) (?:CC=(.*) )?TID=([0-9]*) TIMESTAMP=([0-9]*) HMAC=(.*) ECDSA_KEY=(.) ECDSA=(.*)/m';
             $res = preg_match($comfortpayHmacPattern, $content, $result);
             if ($res) {
                 $mailContent->setAmount($result[1]);

--- a/tests/TatraBankaSimpleMailParserTest.php
+++ b/tests/TatraBankaSimpleMailParserTest.php
@@ -83,6 +83,21 @@ class TatraBankaSimpleMailParserTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals('26112016121631', $mailContent->getTransactionDate());
 	}
 
+    public function testHmacComfortpayEmailNoCC()
+    {
+        $email = 'AMT=44.88 CURR=978 VS=4444255333 RES=OK AC=644311 TRES=OK CID=824452 TID=11224444 TIMESTAMP=26112016121631 HMAC=b76cb9ddeed7ed0bcf991f19bbbabfb1b76cb9ddeed7ed0bcf991f19bbbabfb1 ECDSA_KEY=1 ECDSA=a5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21';
+        $parser = new TatraBankaSimpleMailParser();
+        $mailContent = $parser->parse($email);
+        $this->assertEquals('44.88', $mailContent->getAmount());
+        $this->assertEquals('4444255333', $mailContent->getVs());
+        $this->assertEquals('b76cb9ddeed7ed0bcf991f19bbbabfb1b76cb9ddeed7ed0bcf991f19bbbabfb1', $mailContent->getSign());
+        $this->assertEquals('OK', $mailContent->getRes());
+        $this->assertEquals('824452', $mailContent->getCid());
+        $this->assertEquals('11224444', $mailContent->getTid());
+        $this->assertEquals('978', $mailContent->getCurrency());
+        $this->assertEquals('26112016121631', $mailContent->getTransactionDate());
+    }
+
 	public function testFailHmacComfortpayEmail()
 	{
 		$email = 'AMT=140.92 CURR=978 VS=5555534283 RES=FAIL TRES=FAIL CC=************1111 TID=11224444 TIMESTAMP=24112016170555 HMAC=b76cb9ddeed7ed0bcf991f19bbbabfb1b76cb9ddeed7ed0bcf991f19bbbabfb1 ECDSA_KEY=1 ECDSA=a5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21';


### PR DESCRIPTION
Fixes #3 