### PR TITLE
Amending cardpayHmac regexp due to optional fields

### DIFF
--- a/src/Parsers/TatraBankaSimpleMailParser.php
+++ b/src/Parsers/TatraBankaSimpleMailParser.php
@@ -54,7 +54,7 @@ class TatraBankaSimpleMailParser implements ParserInterface
                 return $mailContent;
             }
 
-            $comfortpayHmacErrorPattern = '/AMT=(.*) CURR=(.*) VS=(.*) RES=(.*) TRES=(.*) CC=(.*) TID=([0-9]*) TIMESTAMP=([0-9]*) HMAC=(.*) ECDSA_KEY=(.) ECDSA=(.*)/m';
+            $comfortpayHmacErrorPattern = '/AMT=(.*?) CURR=(.*?) VS=(.*?) RES=(.*?) TRES=(.*?) (?:CC=(.*?) )?(?:TID=([0-9]*?) )?TIMESTAMP=([0-9]*?) HMAC=(.*?) ECDSA_KEY=(.) ECDSA=(.*)/m';
             $res = preg_match($comfortpayHmacErrorPattern, $content, $result);
             if ($res) {
                 $mailContent->setAmount($result[1]);

--- a/tests/TatraBankaSimpleMailParserTest.php
+++ b/tests/TatraBankaSimpleMailParserTest.php
@@ -112,4 +112,19 @@ class TatraBankaSimpleMailParserTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals('b76cb9ddeed7ed0bcf991f19bbbabfb1b76cb9ddeed7ed0bcf991f19bbbabfb1', $mailContent->getSign());
 		$this->assertEquals('24112016170555', $mailContent->getTransactionDate());
 	}
+
+	public function testFailHmacComfortpayEmailNoCcTid()
+	{
+		$email = 'AMT=8.98 CURR=978 VS=5555534283 RES=FAIL TRES=FAIL TIMESTAMP=24032020144457 HMAC=b76cb9ddeed7ed0bcf991f19bbbabfb1b76cb9ddeed7ed0bcf991f19bbbabfb1 ECDSA_KEY=1 ECDSA=a5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21081c076caa4a8732e43aa5e75a2e2c21';
+		$parser = new TatraBankaSimpleMailParser();
+		$mailContent = $parser->parse($email);
+		$this->assertEquals('8.98', $mailContent->getAmount());
+		$this->assertEquals('978', $mailContent->getCurrency());
+		$this->assertEquals('5555534283', $mailContent->getVs());
+		$this->assertEquals('FAIL', $mailContent->getRes());
+		$this->assertEmpty($mailContent->getCC());
+		$this->assertEmpty($mailContent->getTid());
+		$this->assertEquals('b76cb9ddeed7ed0bcf991f19bbbabfb1b76cb9ddeed7ed0bcf991f19bbbabfb1', $mailContent->getSign());
+		$this->assertEquals('24032020144457', $mailContent->getTransactionDate());
+	}
 }


### PR DESCRIPTION
Recent emails from the bank don't include all the
fields as it used to. Regexp matching didn't expect
those fields to be missing and failed payments
were not being matched correctly.