### PR TITLE
Add GitHub Pages coverage reporting with automatic badge updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ master, main, feature/coverage-reporting ]
   pull_request:
     branches: [ master, main ]
 
@@ -46,4 +46,85 @@ jobs:
       run: vendor/bin/phpstan analyse
     
     - name: Run tests
-      run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+      run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-html build/coverage
+      
+    - name: Upload coverage reports
+      uses: actions/upload-artifact@v4
+      if: matrix.php-versions == '8.3'
+      with:
+        name: coverage-report
+        path: build/coverage
+        
+  deploy-coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/feature/coverage-reporting'
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+      
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}
+    
+    - name: Download coverage report
+      uses: actions/download-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage
+        
+    - name: Extract coverage percentage
+      id: coverage
+      run: |
+        # Try to extract percentage from HTML report
+        if [ -f coverage/index.html ]; then
+          # Look for the Total row and extract percentage
+          COVERAGE=$(grep -A3 '<td class="success">Total</td>' coverage/index.html | grep -oP '\d+\.\d+(?=%)' | head -1 || true)
+          if [ -z "$COVERAGE" ]; then
+            # Fallback: look for any percentage in success class
+            COVERAGE=$(grep '<td class="success small"><div align="right">' coverage/index.html | grep -oP '\d+\.\d+' | head -1 || true)
+          fi
+          echo "Coverage found: ${COVERAGE}%"
+          echo "percentage=${COVERAGE:-0}" >> $GITHUB_OUTPUT
+        else
+          echo "percentage=0" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Update coverage badge
+      if: success()
+      run: |
+        COVERAGE=${{ steps.coverage.outputs.percentage }}
+        COLOR="red"
+        if (( $(echo "$COVERAGE >= 80" | bc -l) )); then
+          COLOR="brightgreen"
+        elif (( $(echo "$COVERAGE >= 60" | bc -l) )); then
+          COLOR="yellow"
+        elif (( $(echo "$COVERAGE >= 40" | bc -l) )); then
+          COLOR="orange"
+        fi
+        
+        # Update the badge in README.md
+        sed -i "s/coverage-[0-9.]*%25-[a-z]*/coverage-${COVERAGE}%25-${COLOR}/g" README.md
+        
+        # Check if there are changes and commit them
+        if ! git diff --quiet README.md; then
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add README.md
+          git commit -m "Update coverage badge to ${COVERAGE}%"
+          git push origin ${{ github.ref }}
+        fi
+        
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+      
+    - name: Upload to Pages
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: coverage
+        
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- GitHub Pages coverage reporting with HTML reports
+- Automatic coverage badge updates in README
+- GitHub Actions CI badge
+
+### Changed
+- Updated all GitHub Actions to v4 to fix deprecation warnings
+- Improved PHPUnit configuration with proper coverage filters
+
+### Removed
+- Code Climate badges (service discontinued)
+
 ## [3.0.0] - 2025-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@ Currently supports:
 - **ČSOB SK** - Slovak ČSOB emails (SkCsobMailParser)
 
 
-[![Build Status](https://secure.travis-ci.org/tomaj/bank-mails-parser.png)](http://travis-ci.org/tomaj/bank-mails-parser)
-[![Test Coverage](https://codeclimate.com/github/tomaj/bank-mails-parser/badges/coverage.svg)](https://codeclimate.com/github/tomaj/bank-mails-parser/coverage)
-[![Code Climate](https://codeclimate.com/github/tomaj/bank-mails-parser/badges/gpa.svg)](https://codeclimate.com/github/tomaj/bank-mails-parser)
-
+[![CI](https://github.com/tomaj/bank-mails-parser/actions/workflows/ci.yml/badge.svg)](https://github.com/tomaj/bank-mails-parser/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-95.13%25-brightgreen.svg)](https://tomaj.github.io/bank-mails-parser/)
 [![Latest Stable Version](https://poser.pugx.org/tomaj/bank-mails-parser/v/stable.svg)](https://packagist.org/packages/tomaj/bank-mails-parser)
 [![Latest Unstable Version](https://poser.pugx.org/tomaj/bank-mails-parser/v/unstable.svg)](https://packagist.org/packages/tomaj/bank-mails-parser)
 [![License](https://poser.pugx.org/tomaj/bank-mails-parser/license.svg)](https://packagist.org/packages/tomaj/bank-mails-parser)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
     </report>
   </coverage>
   <logging/>


### PR DESCRIPTION
## Summary

This PR replaces the deprecated Code Climate integration with GitHub Pages coverage reporting and adds an automatically updating coverage badge.

## Changes

- 🔄 **Replace Code Climate badges** with GitHub Actions CI badge and custom coverage badge
- 📊 **Add coverage reporting** via GitHub Pages (available at https://tomaj.github.io/bank-mails-parser/)
- 🤖 **Automatic badge updates** - coverage percentage updates automatically after each CI run
- ⬆️ **Update GitHub Actions** to v4 (fixes deprecation warnings)
- 🔧 **Configure PHPUnit** with proper coverage filters
- ✅ **Current coverage: 95.13%**

## Technical Details

- Added coverage filter to `phpunit.xml.dist` to properly calculate code coverage
- Integrated coverage report generation into CI workflow
- Set up GitHub Pages deployment for HTML coverage reports
- Coverage badge automatically updates with the actual percentage and appropriate color
- All GitHub Actions updated to latest versions to fix deprecation issues

## Testing

The coverage reporting has been tested in the feature branch and is working correctly:
- CI runs successfully on all PHP versions (7.4, 8.0, 8.1, 8.2, 8.3)
- Coverage reports are generated and uploaded
- Badge updates automatically with the correct percentage
- GitHub Pages deployment works correctly

## Screenshots

Coverage badge shows: \![Coverage](https://img.shields.io/badge/coverage-95.13%25-brightgreen.svg)